### PR TITLE
Changes to imporve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+./build/
+./debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ if("${isSystemDir}" STREQUAL "-1")
    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 endif()
 
+# Use cmake -DGPROF=1 to add gnu profilier.
+if(GPROF)
+  MESSAGE("Adding (gnu) profiling to target all")
+  add_definitions(-pg)
+  set(CMAKE_EXE_LINKER_FLAGS "-pg")
+endif(GPROF)
+
+
 #### C++11 Support ####
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/src/Individual.cpp
+++ b/src/Individual.cpp
@@ -3,69 +3,96 @@
 using namespace std;
 
 
-void printGenotype(haplotype &h)
+
+void printGenotype(haplotype *h, int hapSize)
 {
-    for(unsigned int i=0; i<h.size(); i++)
-        cout << h.at(i) << ",";
-    cout << endl;
+  for(int i = 0; i < hapSize; i++)
+    cout << h[i] << ",";
+  cout << endl;
 }
 
 bool Individual::nsi(gamete &dad)
 {
-    return true;
+  return true;
 }
 
 bool Individual::psi(gamete &dad)
 {
-    if (m_nPosition == dad.par[0])
-        return false;
-    return true;
+  if (m_nPosition == dad.par[0])
+    return false;
+  return true;
 }
 
 bool Individual::gsi(gamete &dad)
 {
-    if (m_genes.g[0][0] == dad.h[0])
-        return false;
-    if (m_genes.g[1][0] == dad.h[0])
-        return false;
-    return true;
+  if (m_genes.g.h1[0] == dad.h[0])
+    return false;
+  if (m_genes.g.h2[0] == dad.h[0])
+    return false;
+  return true;
 }
 
 bool Individual::ssi(gamete &dad)
 {
-    if (m_genes.g[0][0] == dad.s.first)
-        return false;
-    if (m_genes.g[1][0] == dad.s.first)
-        return false;
-    if (m_genes.g[0][0] == dad.s.second)
-        return false;
-    if (m_genes.g[1][0] == dad.s.second)
-        return false;
-    return true;
+  if (m_genes.g.h1[0] == dad.s.first)
+    return false;
+  if (m_genes.g.h2[0] == dad.s.first)
+    return false;
+  if (m_genes.g.h1[0] == dad.s.second)
+    return false;
+  if (m_genes.g.h2[0] == dad.s.second)
+    return false;
+  return true;
 
 }
 
 bool Individual::bsi(gamete &dad)
 {
-    unsigned int d1 = getDomRank(dad.s.first);
-    unsigned int d2 = getDomRank(dad.s.second);
-	unsigned int dominant;
-    if (d1 >= d2)
-        dominant = dad.s.first;
-    else 
-        dominant = dad.s.second;
-    if (m_genes.g[0][0] == dominant)
-        return false;
-    if (m_genes.g[1][0] == dominant)
-        return false;
-    return true;
+  unsigned int d1 = getDomRank(dad.s.first);
+  unsigned int d2 = getDomRank(dad.s.second);
+  unsigned int dominant;
+  if (d1 >= d2)
+    dominant = dad.s.first;
+  else 
+    dominant = dad.s.second;
+  if (m_genes.g.h1[0] == dominant)
+    return false;
+  if (m_genes.g.h2[0] == dominant)
+    return false;
+  return true;
 }
 
-gamete Individual::makeGamete(xorshift64& rand, int m)
+gamete *Individual::makeGameteHelper(int p, int m, haplotype *g0, haplotype *g1, haplotype *par0, haplotype *par1)
 {
+  // Helper class for makeGamete(). Replaced vector::assign() with cstring
+  // memcpy (on array) for efficency.
+
+  gamete *g = new gamete(m);
+
+  // Take the first p alleles from g0 and par0, the remaining alleles
+  // come from g1/par1 
+  memcpy(g->h, g0, p*sizeof(haplotype));
+  memcpy(g->gpar, par0, p*sizeof(haplotype));
+
+  if(p<m+1)
+    {
+      // copy starting from the p'th index
+      memcpy(&(g->h[p]), &(g1[p]), (m+1-p)*sizeof(haplotype));
+      memcpy(&(g->gpar[p]), &(par1[p]), (m+1-p)*sizeof(haplotype));
+    }    
+  
+  return g;
+} 
+		   
+
+		   
+
+gamete *Individual::makeGamete(xorshift64& rand, int m)
+{
+
     unsigned int r = rand.get_uint32();
     unsigned int h0 = r & 1;
-    unsigned int h1 = (h0+1)&1;
+    //unsigned int h1 = (h0+1)&1;
     r >>= 1;
     int p = m+1;
     while ((r & 1) && (p >= 1))
@@ -74,34 +101,89 @@ gamete Individual::makeGamete(xorshift64& rand, int m)
         --p;
     }
 
-    gamete g;
-    g.h.assign(m_genes.g.at(h0).begin(),(m_genes.g.at(h0).begin()+p));
-    g.gpar.assign(m_genes.par.at(h0).begin(),m_genes.par.at(h0).begin()+p);
-    g.par.assign((m+1),m_nPosition);
-
-    if(p<m+1)
-    {
-        g.h.insert(g.h.end(),m_genes.g.at(h1).begin()+p, m_genes.g.at(h1).end());
-        g.gpar.insert(g.gpar.end(),m_genes.par.at(h1).begin()+p, m_genes.par.at(h1).end());
-    }
-    g.del = (r&1) ? m_genes.del.first : m_genes.del.second;
-    g.s = make_pair(m_genes.g.at(h0).front(), m_genes.g.at(h1).front());
+    
+    gamete *g;
+    if(h0 == 0)
+      {
+	g = makeGameteHelper(p, m, m_genes.g.h1, m_genes.g.h2, m_genes.par.h1, m_genes.par.h2);
+	g->s = make_pair(m_genes.g.h1[0], m_genes.g.h2[0]);
+      }
+    else
+      {
+	g = makeGameteHelper(p, m, m_genes.g.h2, m_genes.g.h1, m_genes.par.h2, m_genes.par.h1);
+	g->s = make_pair(m_genes.g.h2[0], m_genes.g.h1[0]);
+      }
+    
+    // Fill in the array 
+    fill_n(g->par, m+1, m_nPosition);
+    g->del = (r&1) ? m_genes.del.first : m_genes.del.second;
+    
     return g;
 }
 
-void Individual::initGenes(int m, haplotype &dad, haplotype &mom)
+
+
+void Individual::initVars(unsigned int pos, int nOvules, int nMarkers, unsigned int nWeight, unsigned int mX, unsigned int mY)
 {
-    m_genes.g.push_back(dad);
-    m_genes.g.push_back(mom);
-    haplotype h;
-    h.assign((m+1),-1);
-    for(int i=0; i<2; ++i)
+  // Added due to issue where one of the constructors was initializing a variable
+  // but not the other. Initialize all Individual's variables/settings here
+  m_nMarkers = nMarkers;
+  m_nOvules = nOvules;
+  m_nPosition = pos;
+  m_nWeight = nWeight;
+  m_vOWeights.assign(nOvules, 0);
+
+  // store x and y position on grid at initialization instead of during the loop
+  maxX = mX;
+  maxY = mY;
+  x_coord = pos/mX;
+  y_coord = pos%mY;
+
+  // allocate an array of gametes that will be filled in by 
+  m_vOvules = new gamete*[nOvules];
+  for(int i = 0; i < nOvules; i++)
     {
-        m_genes.par.push_back(h);
-        m_genes.gpar.push_back(h);
-    }
-    m_genes.del = std::make_pair(0,0);
+      gamete *gam = new gamete(nMarkers);
+      m_vOvules[i] = gam;
+    } 
 }
+
+void Individual::initGenes(int m, haplotype *dad, haplotype *mom)
+{
+  // genes are a reference to the genotype already created on the heap 
+  m_genes.g.h1 = dad;
+  m_genes.g.h2 = mom;
+
+  
+  // created holders for parent/grandparent genotype
+  m_genes.par.h1 = new haplotype[m+1];
+  m_genes.par.h2 = new haplotype[m+1];
+  m_genes.gpar.h1 = new haplotype[m+1];
+  m_genes.gpar.h2 = new haplotype[m+1];
+  
+
+  // The individual's parent and grandparent genome is unknown.
+  // TODO: If NULL_GENE == 0 then we can use memset which is faster.
+  fill_n(m_genes.par.h1, m+1, NULL_GENE);
+  fill_n(m_genes.par.h2, m+1, NULL_GENE);
+  fill_n(m_genes.gpar.h1, m+1, NULL_GENE);
+  fill_n(m_genes.gpar.h2, m+1, NULL_GENE);
+  
+  // no deleterous allele yet
+  m_genes.del = std::make_pair(0,0);
+}
+
+void Individual::setCoordinates(int position, int nMaxX, int nMaxY)
+{
+  // Since each individual doesn't change location on the grid, calculate
+  // the x and y coordinates once instead of calling i2xy() every generation.
+  // Could not find any condition where it would be neccessary to call function
+  // but added it anyways.
+  assert(0 <= position && position < nMaxX*nMaxY);
+  x_coord = position/nMaxX;
+  y_coord = position%nMaxY;
+}
+
 
 void Individual::clearOvuleWeight(int nOvules)
 {
@@ -112,3 +194,19 @@ dominance Individual::dRank;
 string Individual::name;
 typedef bool(Individual::*fptr)(gamete&);
 fptr Individual::op;
+
+
+Individual::~Individual()
+{
+  // This should only be called on initialization (when copy is put into pop
+  // vector) and at the end of the program. 
+  delete[] m_genes.g.h1;
+  delete[] m_genes.g.h2;
+  delete[] m_genes.par.h1;
+  delete[] m_genes.par.h2;
+  delete[] m_genes.gpar.h1;
+  delete[] m_genes.gpar.h2;
+  for(unsigned int a = 0; a < m_nOvules; a++)
+    delete m_vOvules[a]; // delete every referenced object
+  delete [] m_vOvules; // delete the array of reference
+}

--- a/src/Pop.cpp
+++ b/src/Pop.cpp
@@ -44,75 +44,81 @@ inline int xy2i(position xy, int mx, int my) {
 
 void Population::initialize(int nMaxX, int nMaxY, string bound, int nPollen, int nOvule, int nMarkers,float dSigmaP, float dSigmaS,  string si, string dist_name)
 {
-    m_nMaxX = nMaxX;
-    m_nMaxY = nMaxY;
-    m_nPollen = nPollen;
-    m_nOvule = nOvule;
-    m_nMarkers = nMarkers;
-    m_nIndividuals = nMaxX * nMaxY;
-    m_nSalleles = 0;
-    m_nAlleles = 0;
-    ostringstream out;
-    m_dSigmaP = dSigmaP;
-    m_dSigmaS = dSigmaS;
-    out << "Dispersal distribution set to ";
-    if (dist_name != "disk"){
-        dist.initialize(dist_name);
-        pDisperse = &Population::pDisperseDist;
-        sDisperse = &Population::sDisperseDist;
-        out << dist.getName() << ".\n";
-    }
-    else{
-        pdisk.initialize((double)(2.0*m_dSigmaP));
-        sdisk.initialize((double)(2.0*m_dSigmaS));
-        pDisperse = &Population::pDisperseDisk;
-        sDisperse = &Population::sDisperseDisk;
-        out << "Disk" << ".\n";
-    }
-    out << "Landscape set to ";
-    if (bound == "torus"){
-        out << "torus" << endl;
-        newXY = &Population::periodic;
-    }
-    else{
-        out << "rectangle" << endl;
-        newXY = &Population::absorbing;
-    }
-
-    Individual::initialize(si);
-    Individual::initDomRank(m_myrand,2*m_nIndividuals);
-
-    // Initialize Population: each individual has unique allele
-    for(int iii=0; iii<m_nIndividuals; iii++)
+  m_nMaxX = nMaxX;
+  m_nMaxY = nMaxY;
+  m_nPollen = nPollen;
+  m_nOvule = nOvule;
+  m_nMarkers = nMarkers;
+  m_nIndividuals = nMaxX * nMaxY;
+  m_nSalleles = 0;
+  m_nAlleles = 0;
+  ostringstream out;
+  m_dSigmaP = dSigmaP;
+  m_dSigmaS = dSigmaS;
+  out << "Dispersal distribution set to ";
+  if (dist_name != "disk")
     {
-        haplotype h0;
-        haplotype h1;
-        h0.push_back(m_nSalleles++);
-        h1.push_back(m_nSalleles++);
-        for(int jjj=0; jjj<nMarkers; jjj++)
-        {
-            h0.push_back(m_nAlleles++);
-            h1.push_back(m_nAlleles++);
-        }
-
-        m_vPop1.emplace_back(iii,m_nOvule,m_nMarkers,h0,h1);
-        m_vPop2.emplace_back(iii,m_nOvule,m_nMarkers);
+      dist.initialize(dist_name);
+      pDisperse = &Population::pDisperseDist;
+      sDisperse = &Population::sDisperseDist;
+      out << dist.getName() << ".\n";
+    }
+  else
+    {
+      pdisk.initialize((double)(2.0*m_dSigmaP));
+      sdisk.initialize((double)(2.0*m_dSigmaS));
+      pDisperse = &Population::pDisperseDisk;
+      sDisperse = &Population::sDisperseDisk;
+      out << "Disk" << ".\n";
+    }
+  out << "Landscape set to ";
+  if (bound == "torus")
+    {
+      out << "torus" << endl;
+      newXY = &Population::periodic;
+    }
+  else
+    {
+      out << "rectangle" << endl;
+      newXY = &Population::absorbing;
     }
 
+  Individual::initialize(si);
+  Individual::initDomRank(m_myrand,2*m_nIndividuals);
 
-    out << "Self-Incompatibility set to " << Individual::getName() << ".\n";
-    cout << out.str();
-    pout << out.str();
+  
+  // Initialize Population: each individual has unique allele
+  for(int iii=0; iii<m_nIndividuals; iii++)
+    {
+      haplotype *h0 = new haplotype[nMarkers+1];
+      haplotype *h1 = new haplotype[nMarkers+1];
+
+      h0[0] = m_nSalleles++;
+      h1[0] = m_nSalleles++;
+      for(int jjj=1; jjj<nMarkers+1; jjj++)
+        {
+	  h0[jjj] = m_nAlleles++;
+	  h1[jjj] = m_nAlleles++;
+        }
+      
+      m_vPop1.emplace_back(iii, m_nOvule, m_nMarkers, m_nMaxX, m_nMaxY, h0, h1);
+      m_vPop2.emplace_back(iii, m_nOvule, m_nMarkers, m_nMaxX, m_nMaxY);
+    }
+
+  out << "Self-Incompatibility set to " << Individual::getName() << ".\n";
+  cout << out.str();
+  pout << out.str();
 
 }
+
 
 void Population::param(double dSMut, double dMMut, double dDMut, double dPdel, unsigned int seed)
 {
     //set Random seed
     if (seed==0) {
-        seed = create_random_seed();
-        pout << "Using Generated PRNG Seed: "<< seed << endl;
-        cout << "Seed " << seed << endl;
+      seed = create_random_seed();
+      pout << "Using Generated PRNG Seed: "<< seed << endl;
+      cout << "Seed " << seed << endl;
     }
     m_myrand.seed(seed);
     m_pDel = dPdel;
@@ -137,30 +143,34 @@ inline void Population::mutCountDec() {
 
 void Population::mutate(gamete &g)
 {
+
     if (--m_nMutCount > 0)
-        return;
+      return;
+    
     setMutCount();
     double rand = m_myrand.get_double52();
     if (rand < m_pDMut)
-        {
+      {
         g.del = 1;
         return;
-        }
+      }
     if ((rand < (m_pSMut+m_pDMut)) && (rand >= m_pDMut))
-        {
-        g.h.front() = m_nSalleles++;
+      {
+        g.h[0] = m_nSalleles++;
         Individual::addDomRank(m_myrand.get_uint64());
         return;
-        }
+      }
     if (rand >= (m_pSMut+m_pDMut))
-        {
-        g.h.at(1+m_myrand.get_uint(m_nMarkers)) = m_nAlleles++;
+      {
+        g.h[1+m_myrand.get_uint(m_nMarkers)] = m_nAlleles++;
         return;
-        }
+      }
+    
 }
 
 void Population::evolve(int nBurnIn, int nGenerations, int nSample)
 {
+
     //run burn-in period
     for(int ggg=0;ggg<nBurnIn;++ggg)
     {
@@ -182,8 +192,11 @@ void Population::evolve(int nBurnIn, int nGenerations, int nSample)
             seedDispersal(mom);
         if (ggg % nSample == 0)
             samplePop(ggg);
+
         std::swap(m_vPop1,m_vPop2);
+      
     }
+    
 }
 
 inline int wrap_around(int x, int w) {
@@ -257,13 +270,16 @@ int Population::pDisperseDisk(int x, int y)
 
 void Population::pollenDispersal(int dad)
 {
-
-    Individual dadHere = m_vPop1.at(dad);
+    Individual &dadHere = m_vPop1.at(dad);
     if(dadHere.weight() == 0)
         return;
-    position xy = i2xy(dad,m_nMaxX,m_nMaxY);
-    int nX = xy.first;
-    int nY = xy.second;
+
+    int nX = dadHere.coordX();
+    int nY = dadHere.coordY();
+    ////position xy = i2xy(dad, m_nMaxX, m_nMaxY);
+    ////int nX = xy.first;
+    ////int nY = xy.second;
+
     for (int p=0; p < m_nPollen; p++)
     {
         int nNewCell = (this->*pDisperse)(nX, nY);
@@ -278,63 +294,92 @@ void Population::pollenDispersal(int dad)
             mutCountDec();
             continue;
         }
-        gamete pollen = dadHere.makeGamete(m_myrand,m_nMarkers);
-        mutate(pollen);
-        if(!(momHere(pollen))) //check compatibility
-            continue;
-        unsigned int nPollenWeight = m_myrand.get_uint32();
+
+	unsigned int nPollenWeight = m_myrand.get_uint32();
         int ovule = m_myrand.get_uint(m_nOvule);
         if (nPollenWeight < momHere.ovuleWeight(ovule))
-            continue;
+	  continue;
+
+        gamete *pollen = dadHere.makeGamete(m_myrand,m_nMarkers);
+        mutate(*pollen);
+        if(!(momHere(*pollen))) //check compatibility
+	  {
+	    delete pollen;
+	    continue;
+	  }
+	
+
+	// Moved conditional prior to make gamete for efficiency
+	//unsigned int nPollenWeight = m_myrand.get_uint32();
+        //int ovule = m_myrand.get_uint(m_nOvule);
+        //if (nPollenWeight < momHere.ovuleWeight(ovule))
+	//  {
+	//    delete pollen;
+        //    continue;
+	//  }
+
         momHere.setOvuleWeight(nPollenWeight,ovule);
         momHere.setOvuleGenes(pollen,ovule);
+	
     }
 }
 
 void Population::seedDispersal(int mom)
 {
-    Individual &momHere = m_vPop1[mom];
-    if(momHere.weight() == 0) //No plant here
+  Individual &momHere = m_vPop1[mom];
+  if(momHere.weight() == 0) //No plant here
     {
-        momHere.clearOvuleWeight(m_nOvule);  //clear out ovules for next generation
-        return;
+      momHere.clearOvuleWeight(m_nOvule);  //clear out ovules for next generation
+      return;
     }
-    momHere.setWeight(0); //clear out weight to mark as completed
-    position xy = i2xy(mom,m_nMaxX,m_nMaxY);  
-    int nX = xy.first;
-    int nY = xy.second;
-    for (int seed=0; seed < m_nOvule; seed++)
+  momHere.setWeight(0); //clear out weight to mark as completed
+
+  int nX = momHere.coordX();
+  int nY = momHere.coordY();
+  //position xy = i2xy(mom,m_nMaxX,m_nMaxY);  
+  //int nX = xy.first;
+  //int nY = xy.second;
+  for (int seed=0; seed < m_nOvule; seed++)
     {
-        if (momHere.ovuleWeight(seed)==0) //No pollen landed in this ovule
+      if (momHere.ovuleWeight(seed)==0) //No pollen landed in this ovule
         {
-            mutCountDec();  //decrease mutation count for the female gamete
-            continue; //skip to next ovule
+	  mutCountDec();  //decrease mutation count for the female gamete
+	  continue; //skip to next ovule
         }
-        momHere.setOvuleWeight(0,seed); //clear out weight 
-        int nNewCell = (this->*sDisperse)(nX, nY); 
-        if (nNewCell == -1) //reject if dispersal out of landscape
+      momHere.setOvuleWeight(0, seed); //clear out weight 
+
+      int nNewCell = (this->*sDisperse)(nX, nY); 
+      if (nNewCell == -1) //reject if dispersal out of landscape
         {
-            mutCountDec();
-            continue;
+	  mutCountDec();
+	  continue;
         }
-        unsigned int nSeedWeight = m_myrand.get_uint32();
-        if (nSeedWeight < m_vPop2[nNewCell].weight())
+      unsigned int nSeedWeight = m_myrand.get_uint32();
+      if (nSeedWeight < m_vPop2[nNewCell].weight())
         {
-            mutCountDec();
-            continue;
+	  mutCountDec();
+	  continue;
         }
-        gamete pollen = momHere.ovule(seed);
-        gamete ovule = momHere.makeGamete(m_myrand,m_nMarkers);
-        mutate(ovule);
-        if (ovule.del==1 && pollen.del==1){ // check if homozygous for deleterious mutation
-            if (m_pDel == 1.0 || m_myrand.get_double52() < m_pDel){ //Check if lethal
-                m_nLethal++;
-                continue;
-            }
-        }
-        m_vPop2[nNewCell].newIndividual(pollen,ovule,nSeedWeight);
+
+      gamete *pollen = momHere.ovule(seed);
+      gamete *ovule = momHere.makeGamete(m_myrand,m_nMarkers);
+      mutate(*ovule);
+      if (ovule->del==1 && pollen->del==1){ // check if homozygous for deleterious mutation
+	if (m_pDel == 1.0 || m_myrand.get_double52() < m_pDel){ //Check if lethal
+	  m_nLethal++;
+	  delete ovule;
+	  continue;
+	}
+      } 
+     
+      // TODO: newIndividual should hold the reference to ovule and pollen instead
+      // of making a copy.
+      m_vPop2[nNewCell].newIndividual(pollen, ovule, nSeedWeight);
+      
+      delete ovule;	
     }
 }
+
 
 
 double euclideanDist2(int i, int j, int mx, int my) {
@@ -363,9 +408,6 @@ template<typename T>
 inline T sq(const T& t) {
 	return t*t;
 }
-
-
-
 
 
 
@@ -415,17 +457,21 @@ void Population::samplePop(int gen)
 
         if(m==0)
             s2 = 0.5*stats.sum_dist2/M;
+
         double ibd = stats.num_ibd/(1.0*sampleSz);
         double hibd = stats.num_homo/(1.0*sampleSz);
         double f = dt/sq(M);
         double Ke = 1.0/f;
+
         double theta_ke = Ke-1.0;
         double N_ke = 0.25*theta_ke/m_pMut;
         double Nb_ke = 4.0*M_PI*s2*N_ke/(m_nMaxX*m_nMaxY);
         double Ko = (double)stats.num_allele.size();
         string t = "\t";
         int hoDom = sampleSz - stats.num_del1 - stats.num_del2;
-        dout <<gen<<t<<m<<t<<ibd<<t<<hibd<<t<<Ko<<t<<Ke<<t<<s2<<t<<theta_ke<<t<<N_ke<<t<<Nb_ke<<t<<m_nLethal<<t<<stats.num_del2<<t<<stats.num_del1<<t<<hoDom<<m_nIndividuals-popCount<<endl;
+
+	// TODO: Try using fopen/fwritef, the c routines are often faster than c++
+	dout <<gen<<t<<m<<t<<ibd<<t<<hibd<<t<<Ko<<t<<Ke<<t<<s2<<t<<theta_ke<<t<<N_ke<<t<<Nb_ke<<t<<m_nLethal<<t<<stats.num_del2<<t<<stats.num_del1<<t<<hoDom<<m_nIndividuals-popCount<<endl;
 
     }
 }

--- a/src/Pop.h
+++ b/src/Pop.h
@@ -27,7 +27,7 @@
 class Population
 {
 private:
-    int m_nMaxX;
+  int m_nMaxX;
     int m_nMaxY;
     int m_nPollen;
     int m_nOvule;
@@ -38,7 +38,7 @@ private:
     int m_nLethal; //number of abortions
     double m_dSigmaP;
     double m_dSigmaS;
-	double m_pMut;
+    double m_pMut;
     double m_pDMut;
     double m_pSMut;
     double m_pDel;
@@ -49,8 +49,10 @@ private:
 	Disk sdisk;
 	std::ofstream & pout;
 	std::ofstream & dout;
+	// TODO: See if using Individual **m_vPop1 will give better results
 	std::vector<Individual> m_vPop1;
 	std::vector<Individual> m_vPop2;
+
 	std::vector<unsigned int> m_vWeights1;
 	std::vector<unsigned int> m_vWeights2;
 
@@ -77,11 +79,17 @@ public:
     Population(std::ofstream &p, std::ofstream &d): pout(p), dout(d) {};
     void initialize(int nMaxX, int nMaxY, std::string bound, int nPollen, int nOvule, int nMarkers, float dSigmaP, float dSigmaS,std::string si, std::string dist_name);
     void param(double dSMut, double dMMut, double dDMut, double dPdel, unsigned int seed);
-	void evolve(int nGenerations, int nBurnIn, int nSample);
+    void evolve(int nGenerations, int nBurnIn, int nSample);
+    
+    ~Population()
+      {
+
+      }
+    
 };
 
-typedef std::vector<unsigned int> haplotype;
-typedef std::vector<haplotype> genotype;
+//typedef std::vector<unsigned int> haplotype;
+//typedef std::vector<haplotype> genotype;
 typedef std::pair<int,int> xycoord;
 
 #endif // POP_H_INCLUDED

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -36,6 +36,7 @@ double Disk::getMaxX(){
         if((mX <= cellRange[i]) && (mX > cellRange[i-1]))
             return i;
     }
+    return 0;
 }
 
 pair<double,double> Disk::pol2xy(double theta)
@@ -56,6 +57,7 @@ int Disk::getBin(double x){
         if(x <= cellRange[i+1])
             return i;
     }
+    return vecDim-1;
 }
 
 void Disk::areas(double x1, double x2, int i){


### PR DESCRIPTION
- Changed haplotype from vector to array and used memcpy instead of assigned. Since haplotype doesn't change size an array is preferable.
- Unrolled the genotype from a 2D vector of haplotypes to two seperate haplotypes. Faster access time than trying to resolve vector index.
- Make gamete was returning a copy of a gamete. Changed to return a pointer to the heap.
- pollenDispersal() was returning a copy of an Individual. Changed to return a reference.
- In pollenDispersal moved conditional check between two random integers to top of loop.
- Instead of calling i2xy() each time an individual is processed just keep the x and y coordinates a Individual class variables.
